### PR TITLE
Replace hardcoded ANCHORE_CLI_URL

### DIFF
--- a/image-scanning-admission-controller.yaml
+++ b/image-scanning-admission-controller.yaml
@@ -78,7 +78,7 @@ type: Opaque
 stringData:
   config.yaml: |-
       ANCHORE_CLI_TOKEN: {{ANCHORE_CLI_TOKEN}}
-      ANCHORE_CLI_URL: https://api.sysdigcloud.com/api/scanning/v1/anchore
+      ANCHORE_CLI_URL: {{ANCHORE_CLI_URL}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
`./scripts/deploy.sh` requires two env variables to execute, however only one was being used

By removing the hardcoded anchore URL, `deploy.sh` now functions as described and `deploy.sh` can now be used for on-prem installations